### PR TITLE
Fixes for Android resource linking failed

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace "carnegietechnologies.gallery_saver"
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.1"
+    version: "3.2.0"
   http:
     dependency: transitive
     description:


### PR DESCRIPTION
Flutter 3.24.3 
Tools • Dart 3.5.3 • DevTools 2.37.3

While building apk for Android this issue occured

Android resource linking failed
     ERROR: /Users/aria/Desktop/Personal/uno-user-app/build/gallery_saver_plus/intermediates/merged_res/release/values/values.xml:211: AAPT: error: resource android:attr/lStar not found.
     
Update: I have bumped the version for compile sdk, gradle 
Tested against my project and is woking fine

- close #6 