### PR TITLE
Add support for AVIF formats

### DIFF
--- a/lib/files.dart
+++ b/lib/files.dart
@@ -16,7 +16,8 @@ const List<String> imageFormats = [
   '.gif',
   '.webp',
   '.tif',
-  '.heic'
+  '.heic',
+  '.avif'
 ];
 const http = 'http';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: gallery_saver_plus
 description: Saves images and videos from network or temporary file to external
   storage. Both images and videos will be visible in Android Gallery and iOS
   Photos.
-version: 3.2.4
+version: 3.2.5
 homepage: https://github.com/mafreud/gallery_saver_plus
 
 environment:


### PR DESCRIPTION
AVIF is now supported on Android and iOS, and is a much better format for storaging images.