### PR TITLE
Update Android compileSdkVersion to 36

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace "carnegietechnologies.gallery_saver"
-    compileSdkVersion 31
+    compileSdkVersion 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17


### PR DESCRIPTION
This pull request updates the Android compileSdkVersion from 31 to 36 to align with the latest Android SDK requirements. This ensures improved compatibility with newer Android tooling and helps maintain compliance with current Play Store standards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build configuration to target a newer SDK version, improving compatibility with the latest Android devices and ensuring support for current platform standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->